### PR TITLE
Fix: Add context processor for 'now' variable in Jinja templates

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -43,6 +43,10 @@ def index():
     """Home page route"""
     return redirect(url_for('project.list_projects'))
 
+@app.context_processor
+def inject_now():
+    return {'now': datetime.utcnow()}
+
 # Create database tables
 with app.app_context():
     db.create_all()


### PR DESCRIPTION
The 'now' variable was undefined in the base.html template, causing a jinja2.exceptions.UndefinedError.

This commit introduces a Flask context processor `inject_now` which makes the current UTC datetime available as the 'now' variable in all templates. This resolves the error by allowing `{{ now.year }}` to correctly access the year for the footer copyright information.