### PR TITLE
Feat: Increase upload limit to 100MB

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -14,7 +14,7 @@ app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'dev-key-for-pdf-manager
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + os.path.join(os.path.dirname(os.path.dirname(__file__)), 'pdf_manager.db')
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['UPLOAD_FOLDER'] = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'uploads')
-app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024  # 16MB max upload size
+app.config['MAX_CONTENT_LENGTH'] = 100 * 1024 * 1024  # 100MB max upload size
 
 # Ensure upload directories exist
 if not os.path.exists(app.config['UPLOAD_FOLDER']):


### PR DESCRIPTION
I've updated the Flask application's `MAX_CONTENT_LENGTH` to 100MB.

Note: If you're deploying behind a reverse proxy (e.g., Nginx), you may also need to adjust your web server's configuration (e.g., `client_max_body_size` in Nginx) to allow for larger uploads.